### PR TITLE
Replace codehause.org repos with repo.grails.org

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -25,8 +25,7 @@ grails.project.dependency.resolution = {
     mavenLocal()
     mavenCentral()
 
-    mavenRepo "http://snapshots.repository.codehaus.org"
-    mavenRepo "http://repository.codehaus.org"
+    mavenRepo "http://repo.grails.org/grails/repo/"
     mavenRepo "http://download.java.net/maven/2/"
     mavenRepo "http://repository.jboss.com/maven2/"
   }


### PR DESCRIPTION
As codehause.org has shut down, their repos no longer work.

Remove all codehaus.org repositories from BuildConfig.groovy.

Add instead maven repository http://repo.grails.org/grails/repo/ which
has all the Grails plugins we used to get from codehaus.

Implements the same fix as needed for ausaccessfed/federationregistry#197