### PR TITLE
PDF export: add DTD to HTML template

### DIFF
--- a/grails-app/views/templates/_snapshot_pdf.gsp
+++ b/grails-app/views/templates/_snapshot_pdf.gsp
@@ -1,3 +1,4 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html>
   <head>
     <style type="text/css">      


### PR DESCRIPTION
Required to pull in standard entity definitions (special characters, etc)

Otherwise, if any attribute rendered contains special characters (encoded in
intermediate XHTML as entities - like &ntilde;), Attribute Validator returns a
500 with this exception in app.log:

    org.xhtmlrenderer.util.XRRuntimeException: Can't load the XML resource (using TRaX transformer).
    org.xml.sax.SAXParseException; lineNumber: 207; columnNumber: 49; The entity "ntilde" was referenced, but not declared.

Picked XHTML 1.1 - as this is being done by XhtmlDocumentService anyway,
and XHTML 1.1 DTD is included with core-renderer.