### PR TITLE
Build: use custom Groovy 2.0.8 patched for GROOVY-7664

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "aaf-patched-groovy"]
+	path = aaf-patched-groovy
+	url = https://github.com/ausaccessfed/groovy.git

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -18,6 +18,8 @@ grails.project.dependency.resolution = {
   repositories {
     inherits true
 
+    flatDir name:"aaf-patched-groovy", dirs:"aaf-patched-groovy/target/libs"
+
     grailsPlugins()
     grailsHome()
     grailsCentral()
@@ -31,6 +33,7 @@ grails.project.dependency.resolution = {
   }
 
   dependencies {
+    compile "org.codehaus.groovy:groovy-all:2.0.8+aaf.groovy7664"
     compile "commons-collections:commons-collections:3.2.2"
 
     test 'mysql:mysql-connector-java:5.1.18'

--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -1,0 +1,3 @@
+eventCreateWarStart = { name, stagingDir ->
+  ant.delete(dir:"${stagingDir}/WEB-INF/lib/", includes: "groovy-all-2.0.8.jar", verbose: true)
+}


### PR DESCRIPTION
Same approach with submodules as in other projects.

Note that the hook for removing the unpatched version wasn't necessary (only the patched jar was being included in the WAR), but the hook is included for consistency across projects.