### PR TITLE
BuildConfig: add grails/plugins-releases mvn repo

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -27,6 +27,7 @@ grails.project.dependency.resolution = {
     mavenLocal()
     mavenCentral()
 
+    mavenRepo "http://repo.grails.org/grails/plugins-releases/"
     mavenRepo "http://repo.grails.org/grails/repo/"
     mavenRepo "http://download.java.net/maven/2/"
     mavenRepo "http://repository.jboss.com/maven2/"


### PR DESCRIPTION
Sorry, one very very last PR: otherwise, build breaks in a clean environment without cached plugin.

Missed this one when copying in our changes in other projects.